### PR TITLE
Enable to set insecure ssk skip verify from config file

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "github.com/rakutentech/kafka-firehose-nozzle",
 	"GoVersion": "go1.6",
-	"GodepVersion": "v62",
+	"GodepVersion": "v69",
 	"Deps": [
 		{
 			"ImportPath": "github.com/BurntSushi/toml",
@@ -86,7 +86,7 @@
 		},
 		{
 			"ImportPath": "github.com/rakutentech/go-nozzle",
-			"Rev": "152e9e543ce133cda75999f7c717abd012381676"
+			"Rev": "ee4e20ffd9c29a64036c28ca79ebb5be61130b76"
 		},
 		{
 			"ImportPath": "golang.org/x/net/context",

--- a/cli.go
+++ b/cli.go
@@ -163,6 +163,7 @@ func (cli *CLI) Run(args []string) int {
 		Username:       config.CF.Username,
 		Password:       config.CF.Password,
 		SubscriptionID: config.SubscriptionID,
+		Insecure:       config.InsecureSSLSkipVerify,
 		Logger:         logger,
 	}
 

--- a/config.go
+++ b/config.go
@@ -8,9 +8,10 @@ import (
 
 // Config is kafka-firehose-nozzle configuration.
 type Config struct {
-	SubscriptionID string `toml:"subscription_id"`
-	CF             CF     `toml:"cf"`
-	Kafka          Kafka  `toml:"kafka"`
+	SubscriptionID        string `toml:"subscription_id"`
+	InsecureSSLSkipVerify bool   `toml:"insecure_ssl_skip_verify"`
+	CF                    CF     `toml:"cf"`
+	Kafka                 Kafka  `toml:"kafka"`
 }
 
 // CF holds CloudFoundry related configuration.

--- a/config_test.go
+++ b/config_test.go
@@ -18,7 +18,8 @@ func TestLoadConfig(t *testing.T) {
 			in:      "basic.toml",
 			success: true,
 			config: &Config{
-				SubscriptionID: "kafka-firehose-nozzle",
+				SubscriptionID:        "kafka-firehose-nozzle",
+				InsecureSSLSkipVerify: true,
 				CF: CF{
 					DopplerAddr: "wss://doppler.cloudfoundry.net",
 					UAAAddr:     "https://uaa.cloudfoundry.net",

--- a/fixtures/basic.toml
+++ b/fixtures/basic.toml
@@ -1,4 +1,5 @@
 subscription_id = "kafka-firehose-nozzle"
+insecure_ssl_skip_verify = true
 
 [cf]
 doppler_address = "wss://doppler.cloudfoundry.net"

--- a/vendor/github.com/rakutentech/go-nozzle/LICENSE
+++ b/vendor/github.com/rakutentech/go-nozzle/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Rakuten, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/rakutentech/go-nozzle/nozzle.go
+++ b/vendor/github.com/rakutentech/go-nozzle/nozzle.go
@@ -62,8 +62,11 @@ type Config struct {
 	// access token if Token is empty.
 	Password string
 
-	// Insecure is used for insecure connection with doppler.
-	// Default value is false (Connect with TLS).
+	// Insecure is used for skipping verifying insecure connection with doppler
+	// and UAA. Default value is false, not skipping.
+	//
+	// If it true, by default, connection to doppler & UAA will be insecure.
+	// We strongly recommend not to set true instead of testing purpose.
 	Insecure bool
 
 	// DebugPrinter is noaa.DebugPrinter. It's used for debugging

--- a/vendor/github.com/rakutentech/go-nozzle/token.go
+++ b/vendor/github.com/rakutentech/go-nozzle/token.go
@@ -26,8 +26,8 @@ type defaultTokenFetcher struct {
 	username string
 	password string
 	timeout  time.Duration
-
-	logger *log.Logger
+	insecure bool
+	logger   *log.Logger
 }
 
 // Fetch gets access token from UAA server. This auth token
@@ -41,7 +41,7 @@ func (tf *defaultTokenFetcher) Fetch() (string, error) {
 
 	resCh, errCh := make(chan string), make(chan error)
 	go func() {
-		token, err := client.GetAuthToken(tf.username, tf.password, false)
+		token, err := client.GetAuthToken(tf.username, tf.password, tf.insecure)
 		if err != nil {
 			errCh <- err
 		}
@@ -86,6 +86,7 @@ func newDefaultTokenFetcher(config *Config) (*defaultTokenFetcher, error) {
 		timeout:  config.UaaTimeout,
 		username: config.Username,
 		password: config.Password,
+		insecure: config.Insecure,
 		logger:   config.Logger,
 	}
 


### PR DESCRIPTION
Enable it from config file,

```bash
$ cat fixtures/basic.toml
subscription_id = "kafka-firehose-nozzle"
insecure_ssl_skip_verify = true

[cf]
...
```

If it's true, connection to firehose & UAA (when you grab token) will be insecure. This is related to https://github.com/rakutentech/go-nozzle/pull/3