### PR TITLE
Handle upstream channel close

### DIFF
--- a/kafka.go
+++ b/kafka.go
@@ -102,8 +102,14 @@ func (kp *KafkaProducer) Produce(ctx context.Context, eventCh <-chan *events.Env
 	kp.Logger.Printf("[INFO] Start loop to watch events")
 	for {
 		select {
-		case event := <-eventCh:
+		case event, ok := <-eventCh:
+			if !ok {
+				kp.Logger.Printf("[ERROR] Nozzle consumer eventCh is closed")
+				return
+			}
+
 			kp.input(event)
+
 		case <-ctx.Done():
 			// Stop process immediately
 			kp.Logger.Printf("[INFO] Stop kafka producer")


### PR DESCRIPTION
We use [noaa](https://github.com/cloudfoundry/noaa) for consuming firehose logs.
It closes event/error channels after five reconnection attempts (when something wrong on connection between nozzle and firehose). 

Now this nozzle doesn't handle that situation (It continues loop...).
This PR stops nozzle when noaa client closes channel.