### PR TITLE
Handle upstream channel close

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -196,12 +196,34 @@ func (cli *CLI) Run(args []string) int {
 	go func() {
 		for {
 			select {
-			case err := <-nozzleConsumer.Errors():
-				if err == nil {
-					continue
+			// The following comments are from noaa client comments.
+			//
+			// "Whenever an error is encountered, the error will be sent down the error
+			// channel and Firehose will attempt to reconnect up to 5 times.  After five
+			// failed reconnection attempts, Firehose will give up and close the error and
+			// Envelope channels."
+			//
+			// When noaa client gives up recconection to doppler, nozzle should be
+			// terminated instead of infinity loop. We deploy nozzle on CF as CF app.
+			// This means we can ask platform to restart nozzle when terminated.
+			//
+			// In future, we should implement restart/retry fuctionality in nozzle (or go-nozzle)
+			// and avoid to rely on the specific platform (so that we can deploy this anywhere).
+			case err, ok := <-nozzleConsumer.Errors():
+
+				// This means noaa consumer stopped consuming and close its channel.
+				if !ok {
+					logger.Printf("[ERROR] Nozzle consumer's error channel is closed")
+
+					// Call cancellFunc and then stop all nozzle workers
+					cancel()
+
+					// Finish error handline goroutine
+					return
 				}
 
 				// Connection retry is done on noaa side (5 times)
+				// After 5 times but can not be recovered, then channel is closed.
 				logger.Printf("[ERROR] Received error from nozzle consumer: %s", err)
 
 			case err := <-nozzleConsumer.Detects():
@@ -223,10 +245,6 @@ func (cli *CLI) Run(args []string) int {
 		defer cancel()
 
 		for err := range producer.Errors() {
-			if err == nil {
-				continue
-			}
-
 			logger.Printf("[ERROR] Faield to produce logs: %s", err)
 			return
 		}

--- a/kafka.go
+++ b/kafka.go
@@ -102,8 +102,14 @@ func (kp *KafkaProducer) Produce(ctx context.Context, eventCh <-chan *events.Env
 	kp.Logger.Printf("[INFO] Start loop to watch events")
 	for {
 		select {
-		case event := <-eventCh:
+		case event, ok := <-eventCh:
+			if !ok {
+				kp.Logger.Printf("[ERROR] Nozzle consumer eventCh is closed")
+				return
+			}
+
 			kp.input(event)
+
 		case <-ctx.Done():
 			// Stop process immediately
 			kp.Logger.Printf("[INFO] Stop kafka producer")


### PR DESCRIPTION
We use [noaa](https://github.com/cloudfoundry/noaa) for consuming firehose logs.
It closes event/error channels after five reconnection attempts (when something wrong on connection between nozzle and firehose). 

Now this nozzle doesn't handle that situation (It continues loop...).
This PR stops nozzle when noaa client closes channel.