### PR TITLE
Application stats

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -124,6 +124,12 @@ func (cli *CLI) Run(args []string) int {
 	}, "", log.LstdFlags)
 	logger.Printf("[INFO] LogLevel: %s", logLevel)
 
+	// Show basic infomation
+	logger.Printf("[INFO] %s version: %s", Name, Version)
+	logger.Printf("[INFO] Go version: %s (%s/%s)",
+		runtime.Version(), runtime.GOOS, runtime.GOARCH)
+	logger.Printf("[INFO] Num of CPU: %s", runtime.NumCPU())
+
 	// Load configuration
 	config, err := LoadConfig(cfgPath)
 	if err != nil {

--- a/kafka.go
+++ b/kafka.go
@@ -25,7 +25,7 @@ const (
 	DefaultLogMessageTopic  = "log-message"
 )
 
-func NewKafkaProducer(logger *log.Logger, config *Config) (NozzleProducer, error) {
+func NewKafkaProducer(logger *log.Logger, stats *Stats, config *Config) (NozzleProducer, error) {
 	// Setup kafka async producer (We must use sync producer)
 	// TODO (tcnksm): Enable to configure more properties.
 	producerConfig := sarama.NewConfig()
@@ -53,9 +53,9 @@ func NewKafkaProducer(logger *log.Logger, config *Config) (NozzleProducer, error
 	}
 
 	return &KafkaProducer{
-		AsyncProducer: asyncProducer,
-		Logger:        logger,
-
+		AsyncProducer:      asyncProducer,
+		Logger:             logger,
+		Stats:              stats,
 		logMessageTopic:    kafkaTopic.LogMessage,
 		logMessageTopicFmt: kafkaTopic.LogMessageFmt,
 		valueMetricTopic:   kafkaTopic.ValueMetric,
@@ -72,6 +72,7 @@ type KafkaProducer struct {
 	valueMetricTopic string
 
 	Logger *log.Logger
+	Stats  *Stats
 
 	once sync.Once
 }
@@ -127,12 +128,14 @@ func (kp *KafkaProducer) input(event *events.Envelope) {
 	case events.Envelope_HttpStop:
 		// Do nothing
 	case events.Envelope_LogMessage:
+		kp.Stats.Inc(Consume)
 		appID := event.GetLogMessage().GetAppId()
 		kp.Input() <- &sarama.ProducerMessage{
 			Topic: kp.LogMessageTopic(appID),
 			Value: &JsonEncoder{event: event},
 		}
 	case events.Envelope_ValueMetric:
+		kp.Stats.Inc(Consume)
 		kp.Input() <- &sarama.ProducerMessage{
 			Topic: kp.ValueMetricTopic(),
 			Value: &JsonEncoder{event: event},

--- a/kafka_test.go
+++ b/kafka_test.go
@@ -87,7 +87,8 @@ func TestNewKafkaProducer(t *testing.T) {
 		tc.config.Kafka.Brokers = []string{seed.Addr()}
 
 		// Create new kafka producer
-		producer, err := NewKafkaProducer(nil, tc.config)
+		stats := NewStats()
+		producer, err := NewKafkaProducer(nil, stats, tc.config)
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}
@@ -119,5 +120,6 @@ func TestNewKafkaProducer(t *testing.T) {
 				t.Fatalf("expect %q to be eq %q", msg.Topic, tc.topic)
 			}
 		}
+
 	}
 }

--- a/server.go
+++ b/server.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"os"
 
+	_ "net/http/pprof"
+
 	"github.com/fukata/golang-stats-api-handler"
 )
 

--- a/server.go
+++ b/server.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 
 	_ "net/http/pprof"
 
@@ -18,25 +20,61 @@ const (
 	EnvPort = "PORT"
 )
 
-// To run nozzle as PaaS application, we need server.
-// It would be better to have varz endpoint than just returning
-// hello-world thing.
-type VarzServer struct {
+// Server is used for various debugging.
+// It opens runtime stats, pprof and appliclation stats.
+type Server struct {
 	Logger *log.Logger
+	Stats  *Stats
 }
 
 // Start starts listening.
-func (s *VarzServer) Start() {
+func (s *Server) Start() {
 
-	http.HandleFunc("/varz", stats_api.Handler)
+	http.HandleFunc("/", index)
+	http.Handle("/stats/app", &statsHandler{
+		stats: s.Stats,
+	})
+	http.HandleFunc("/stats/runtime", stats_api.Handler)
 
 	port := DefaultPort
 	if p := os.Getenv(EnvPort); p != "" {
 		port = p
 	}
 
-	s.Logger.Printf("[INFO] Start varz-server listening on :%s", port)
+	s.Logger.Printf("[INFO] Start server listening on :%s", port)
 	if err := http.ListenAndServe(":"+port, nil); err != nil {
 		s.Logger.Printf("[ERROR] Failed to start varz-server: %s", err)
 	}
+}
+
+func index(w http.ResponseWriter, _ *http.Request) {
+	body := `
+<a href="https://github.com/rakutentech/kafka-firehose-nozzle">kafka-firehose-nozzle</a> 
+<ul>
+  <li><a href="/stats/runtime">stats/runtime</a></li>
+  <li><a href="/stats/app">stats/app</a></li>
+  <li><a href="/debug/pprof/">pprof</a></li>
+</ul>
+`
+	w.Header().Set("Content-type", "text/html")
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(body))
+}
+
+type statsHandler struct {
+	stats *Stats
+}
+
+func (h *statsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	body, err := h.stats.Json()
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintf(w, "Internal Server Error: %s\n", err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Contentt-Length", strconv.Itoa(len(body)))
+	w.WriteHeader(http.StatusOK)
+	w.Write(body)
 }

--- a/stats.go
+++ b/stats.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+type StatsType int
+
+const (
+	Consume StatsType = iota
+	ConsumeFail
+	Publish
+	PublishFail
+	SlowConsumer
+)
+
+// Stats stores various stats infomation
+type Stats struct {
+	Consume     uint64
+	ConsumeFail uint64
+
+	Publish     uint64
+	PublishFail uint64
+
+	SlowConsumer uint64
+
+	ConsumePerSec uint64
+	PublishPerSec uint64
+}
+
+func NewStats() *Stats {
+	return &Stats{}
+}
+
+func (s *Stats) PerSec() {
+	lastConsume, lastPublish := uint64(0), uint64(0)
+	ticker := time.NewTicker(1 * time.Second)
+	for {
+		select {
+		case <-ticker.C:
+			s.ConsumePerSec = s.Consume - lastConsume
+			s.PublishPerSec = s.Publish - lastPublish
+
+			lastConsume = s.Consume
+			lastPublish = s.Publish
+		}
+	}
+}
+
+func (s *Stats) Inc(statsType StatsType) {
+	switch statsType {
+	case Consume:
+		atomic.AddUint64(&s.Consume, 1)
+	case ConsumeFail:
+		atomic.AddUint64(&s.ConsumeFail, 1)
+	case Publish:
+		atomic.AddUint64(&s.Publish, 1)
+	case PublishFail:
+		atomic.AddUint64(&s.PublishFail, 1)
+	case SlowConsumer:
+		atomic.AddUint64(&s.SlowConsumer, 1)
+	}
+}

--- a/stats_test.go
+++ b/stats_test.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"sync"
 	"testing"
 )
 
-func TestInc(t *testing.T) {
+func TestStatsInc(t *testing.T) {
 
 	s := NewStats()
 
@@ -28,5 +30,32 @@ func TestInc(t *testing.T) {
 	expect := loop * inc
 	if s.Consume != uint64(expect) {
 		t.Fatalf("expect %d to be eq %d", s.Consume, expect)
+	}
+}
+
+func TestStatsJson(t *testing.T) {
+	s := NewStats()
+
+	s.Inc(Consume)
+	s.Inc(Consume)
+	s.Inc(Publish)
+
+	expect := `{
+  "consume": 2,
+  "consume_per_sec": 0,
+  "consume_fail": 0,
+  "publish": 1,
+  "publish_per_sec": 0,
+  "publish_fail": 0,
+  "slow_consumer_alert": 0,
+  "delay": 1
+}`
+
+	b, _ := s.Json()
+
+	var buf bytes.Buffer
+	json.Indent(&buf, b, "", "  ")
+	if buf.String() != expect {
+		t.Fatalf("expect %v to be eq %v", buf.String(), expect)
 	}
 }

--- a/stats_test.go
+++ b/stats_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestInc(t *testing.T) {
+
+	s := NewStats()
+
+	loop := 20
+	inc := 5
+
+	var wg sync.WaitGroup
+	wg.Add(loop)
+	for i := 0; i < loop; i++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < inc; i++ {
+				s.Inc(Consume)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	expect := loop * inc
+	if s.Consume != uint64(expect) {
+		t.Fatalf("expect %d to be eq %d", s.Consume, expect)
+	}
+}


### PR DESCRIPTION
Now we only provide runtime spec (by [fukata/golang-stats-api-handler](https://github.com/fukata/golang-stats-api-handler)). This is not enough for debugging.

This PR will opens application stats like number of consume, number of publish so that we can detect something wrong on nozzle. Not only application stats, but enables `net/http/pprof` for tuning. This is initial step. We should add more stats in future. 

Now we have three endpoints,

- /stats/runtime 
- /stats/app
- /debug/pprof
