### PR TITLE
Add instanceId on stats info

### DIFF
--- a/server.go
+++ b/server.go
@@ -66,6 +66,7 @@ type statsHandler struct {
 }
 
 func (h *statsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+
 	body, err := h.stats.Json()
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/stats.go
+++ b/stats.go
@@ -2,8 +2,18 @@ package main
 
 import (
 	"encoding/json"
+	"os"
+	"strconv"
 	"sync/atomic"
 	"time"
+)
+
+const (
+	defaultInstanceID int = 0
+)
+
+const (
+	EnvCFInstaceIndex = "CF_INSTANCE_INDEX"
 )
 
 type StatsType int
@@ -31,10 +41,28 @@ type Stats struct {
 	// Delay is Consume - Pulish
 	// This indicate how slow publish to kafka
 	Delay uint64 `json:"delay"`
+
+	// InstanceID is ID for nozzle instance.
+	// This is used to identify stats from different instances.
+	// By default, it's defaultInstanceID
+	InstanceID int `json:"instance_id"`
 }
 
 func NewStats() *Stats {
-	return &Stats{}
+	instanceID := defaultInstanceID
+	if idStr := os.Getenv(EnvCFInstaceIndex); len(idStr) != 0 {
+		var err error
+		instanceID, err = strconv.Atoi(idStr)
+		if err != nil {
+			// If it's failed to conv str to int
+			// use default var
+			instanceID = defaultInstanceID
+		}
+	}
+
+	return &Stats{
+		InstanceID: instanceID,
+	}
 }
 
 func (s *Stats) Json() ([]byte, error) {


### PR DESCRIPTION
Now we can not identify which host generates which stats. This PR enables to annotate host/instance info to stats.

For initial implementation, use `CF_INSTANCE_INDEX` (The index number of the cloudfoundry app instance)

We should allow to set via other general env var in future. 