### PR TITLE
Try sending messages on a different partition if a partition is unavailable

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,8 +34,9 @@ type Kafka struct {
 	Brokers []string `toml:"brokers"`
 	Topic   Topic    `toml:"topic"`
 
-	RetryMax     int `toml:"retry_max"`
-	RetryBackoff int `toml:"retry_backoff_ms"`
+	RetryMax       int `toml:"retry_max"`
+	RetryBackoff   int `toml:"retry_backoff_ms"`
+	RepartitionMax int `toml:"repartition_max"`
 }
 
 type Topic struct {

--- a/kafka_test.go
+++ b/kafka_test.go
@@ -201,11 +201,12 @@ func TestKafkaProducer_RoundRobin(t *testing.T) {
 	}
 }
 
-func TestKafkaProducer_error(t *testing.T) {
+func TestKafkaProducer_repartition(t *testing.T) {
 
 	// topic which is used in this test
 	topic := DefaultLogMessageTopic
-	partition := int32(0)
+	partitionBroken := int32(0)
+	partitionOK := int32(1)
 
 	// Create fake brokers (1 leader and 2 seeds)
 	leader := sarama.NewMockBroker(t, int32(0))
@@ -214,16 +215,19 @@ func TestKafkaProducer_error(t *testing.T) {
 	// Create metadata response
 	meta := new(sarama.MetadataResponse)
 	meta.AddBroker(leader.Addr(), leader.BrokerID())
-	meta.AddTopicPartition(topic, partition, leader.BrokerID(), nil, nil, sarama.ErrNoError)
+	meta.AddTopicPartition(topic, partitionBroken, leader.BrokerID(), nil, nil, sarama.ErrNoError)
+	meta.AddTopicPartition(topic, partitionOK, leader.BrokerID(), nil, nil, sarama.ErrNoError)
 	seed.Returns(meta)
 	seed.Returns(meta)
 
 	// Set leader response
-	errorFromBroker := sarama.ErrNotLeaderForPartition
 	var resErr sarama.ProduceResponse
-	resErr.AddTopicPartition(topic, partition, errorFromBroker)
+	resErr.AddTopicPartition(topic, partitionBroken, sarama.ErrNotLeaderForPartition)
 	leader.Returns(&resErr)
 	leader.Returns(&resErr)
+	var resOK sarama.ProduceResponse
+	resOK.AddTopicPartition(topic, partitionOK, sarama.ErrNoError)
+	leader.Returns(&resOK)
 
 	// Create new test kafka producer
 	stats := NewStats()
@@ -258,11 +262,87 @@ func TestKafkaProducer_error(t *testing.T) {
 
 	select {
 	case err := <-producer.Errors():
-		if err.Err != errorFromBroker {
-			t.Fatalf("expect %s to be eq %s", err.Err, errorFromBroker)
+		// Publish should not be success
+		t.Fatalf("expected no error, got %s", err.Err)
+	case <-producer.Successes():
+	}
+}
+
+func TestKafkaProducer_error(t *testing.T) {
+
+	// topic which is used in this test
+	topic := DefaultLogMessageTopic
+	partitionBroken0 := int32(0)
+	partitionBroken1 := int32(1)
+
+	// Create fake brokers (1 leader and 2 seeds)
+	leader := sarama.NewMockBroker(t, int32(0))
+	seed := sarama.NewMockBroker(t, int32(1))
+
+	// Create metadata response
+	meta := new(sarama.MetadataResponse)
+	meta.AddBroker(leader.Addr(), leader.BrokerID())
+	meta.AddTopicPartition(topic, partitionBroken0, leader.BrokerID(), nil, nil, sarama.ErrNoError)
+	meta.AddTopicPartition(topic, partitionBroken1, leader.BrokerID(), nil, nil, sarama.ErrNoError)
+	seed.Returns(meta)
+	seed.Returns(meta)
+	seed.Returns(meta)
+	seed.Returns(meta)
+	seed.Returns(meta)
+	seed.Returns(meta)
+	seed.Returns(meta)
+
+	// Set leader response
+	var resErr0 sarama.ProduceResponse
+	resErr0.AddTopicPartition(topic, partitionBroken0, sarama.ErrNotLeaderForPartition)
+	var resErr1 sarama.ProduceResponse
+	resErr1.AddTopicPartition(topic, partitionBroken1, sarama.ErrNotLeaderForPartition)
+	leader.Returns(&resErr0)
+	leader.Returns(&resErr0)
+	leader.Returns(&resErr1)
+	leader.Returns(&resErr1)
+	leader.Returns(&resErr0)
+	leader.Returns(&resErr1)
+	leader.Returns(&resErr0)
+	leader.Returns(&resErr1)
+
+	// Create new test kafka producer
+	stats := NewStats()
+	producer, err := NewKafkaProducer(nil, stats, &Config{
+		Kafka: Kafka{
+			Brokers: []string{seed.Addr()},
+
+			RetryMax:     1,
+			RetryBackoff: 10,
+		},
+	})
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Create test eventCh where producer gets actual message
+	eventCh := make(chan *events.Envelope)
+
+	// Start producing
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		producer.Produce(ctx, eventCh)
+	}()
+
+	// Send event to producer
+	go func() {
+		// Create test event and send it to channel
+		eventCh <- logMessage("", "", time.Now().UnixNano())
+	}()
+
+	select {
+	case err := <-producer.Errors():
+		if err.Err != sarama.ErrNotLeaderForPartition {
+			t.Fatalf("expected ErrNotLeaderForPartition, got %s", err.Err)
 		}
 	case <-producer.Successes():
-		// Publish should not be success
-		t.Fatalf("expect not to be success")
+		t.Fatalf("expected produce to fail")
 	}
 }


### PR DESCRIPTION
Right now the nozzle will try to write to only available partitions (because we're using sarama's round-robin policy, and this policy will only send to available partitions).
Unfortunately in the interval between when a partition leader fails to when sarama detects it as unavailable messages for the partition will queue up inside sarama and sarama by itself won't reroute them to a different partition (because sarama guarantees the per-partition ordering of messages).

There's a proposal to fix it upstream but it looks like it's not going anywhere. We can easily workaround the issue by retrying failed messages up to a few times, so that they should end up on different, available partitions. The messages will be out-of-order but they contain a timestamp and source information, so the order can be restored if needed.