### PR TITLE
Add buffer on nozzle

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -229,6 +229,8 @@ func (cli *CLI) Run(args []string) int {
 
 				logger.Printf("[INFO] Publish delay: %d", stats.Consume-stats.Publish-stats.PublishFail)
 
+				logger.Printf("[INFO] SubInput buffer: %d", stats.SubInputBuffer)
+
 				logger.Printf("[INFO] Failed consume: %d", stats.ConsumeFail)
 				logger.Printf("[INFO] Failed publish: %d", stats.PublishFail)
 				logger.Printf("[INFO] SlowConsumer alerts: %d", stats.SlowConsumerAlert)

--- a/stats.go
+++ b/stats.go
@@ -24,6 +24,7 @@ const (
 	Publish
 	PublishFail
 	SlowConsumerAlert
+	SubInputBuffer
 )
 
 // Stats stores various stats infomation
@@ -39,6 +40,10 @@ type Stats struct {
 	PublishFail uint64 `json:"publish_fail"`
 
 	SlowConsumerAlert uint64 `json:"slow_consumer_alert"`
+
+	// SubInputBuffer is used to count number of current
+	// buffer on subInput.
+	SubInputBuffer int64 `json:"subinupt_buffer"`
 
 	// Delay is Consume - Pulish
 	// This indicate how slow publish to kafka
@@ -99,5 +104,14 @@ func (s *Stats) Inc(statsType StatsType) {
 		atomic.AddUint64(&s.PublishFail, 1)
 	case SlowConsumerAlert:
 		atomic.AddUint64(&s.SlowConsumerAlert, 1)
+	case SubInputBuffer:
+		atomic.AddInt64(&s.SubInputBuffer, 1)
+	}
+}
+
+func (s *Stats) Dec(statsType StatsType) {
+	switch statsType {
+	case SubInputBuffer:
+		atomic.AddInt64(&s.SubInputBuffer, -1)
 	}
 }

--- a/stats_test.go
+++ b/stats_test.go
@@ -49,6 +49,14 @@ func TestStatsJson(t *testing.T) {
 		s.Inc(Publish)
 	}
 
+	for i := 0; i < 100; i++ {
+		s.Inc(SubInputBuffer)
+	}
+
+	for i := 0; i < 50; i++ {
+		s.Dec(SubInputBuffer)
+	}
+
 	expect := `{
   "consume": 100,
   "consume_per_sec": 0,
@@ -57,6 +65,7 @@ func TestStatsJson(t *testing.T) {
   "publish_per_sec": 0,
   "publish_fail": 50,
   "slow_consumer_alert": 0,
+  "subinupt_buffer": 50,
   "delay": 0,
   "instance_id": 0
 }`


### PR DESCRIPTION
When sarama input buffer is full, whole process (consuming & producing)
is blocked. This PR fix that problem. It prevents blocking on sarama
partition dispatcher. Drop message when buffer is full.

Not only that adding a new buffer layer on nozzle side (subInput).
So that we don't lose logs.