### PR TITLE
Allow setting NOAA IdleTimeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.6.2
+  - 1.6.4
 
 script:
   - make test

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "github.com/rakutentech/kafka-firehose-nozzle",
 	"GoVersion": "go1.6",
-	"GodepVersion": "v69",
+	"GodepVersion": "v79",
 	"Deps": [
 		{
 			"ImportPath": "github.com/BurntSushi/toml",
@@ -86,7 +86,7 @@
 		},
 		{
 			"ImportPath": "github.com/rakutentech/go-nozzle",
-			"Rev": "ee4e20ffd9c29a64036c28ca79ebb5be61130b76"
+			"Rev": "5ea7d8dd3be1bceb05513fcff0a5cba6e806d706"
 		},
 		{
 			"ImportPath": "golang.org/x/net/context",

--- a/cli.go
+++ b/cli.go
@@ -199,12 +199,18 @@ func (cli *CLI) Run(args []string) int {
 	}
 
 	// Setup default nozzle consumer.
-	nozzleConsumer, err := nozzle.NewDefaultConsumer(nozzleConfig)
+	nozzleConsumer, err := nozzle.NewConsumer(nozzleConfig)
 	if err != nil {
 		logger.Printf("[ERROR] Failed to construct nozzle consumer: %s", err)
 		return ExitCodeError
 	}
 
+	err = nozzleConsumer.Start()
+	if err != nil {
+		logger.Printf("[ERROR] Failed to start nozzle consumer: %s", err)
+		return ExitCodeError
+	}
+		
 	// Setup nozzle producer
 	var producer NozzleProducer
 	if debug {

--- a/cli.go
+++ b/cli.go
@@ -44,6 +44,10 @@ const (
 	// DefaultSubscriptionID is default subscription ID for
 	// loggregagor firehose.
 	DefaultSubscriptionID = "debug-kafka-firehose-nozzle"
+
+	// DefaultIdleTimeout is the default timeout for receiving a single message
+	// from the firehose
+	DefaultIdleTimeout = 60 * time.Second
 )
 
 const (
@@ -163,6 +167,10 @@ func (cli *CLI) Run(args []string) int {
 		config.CF.Password = password
 	}
 
+	if config.CF.IdleTimeout == 0 {
+		config.CF.IdleTimeout = int(DefaultIdleTimeout.Seconds())
+	}
+
 	// Initialize stats collector
 	stats := NewStats()
 	go stats.PerSec()
@@ -184,6 +192,7 @@ func (cli *CLI) Run(args []string) int {
 		UaaAddr:        config.CF.UAAAddr,
 		Username:       config.CF.Username,
 		Password:       config.CF.Password,
+		IdleTimeout:    time.Duration(config.CF.IdleTimeout) * time.Second,
 		SubscriptionID: config.SubscriptionID,
 		Insecure:       config.InsecureSSLSkipVerify,
 		Logger:         logger,

--- a/config.go
+++ b/config.go
@@ -27,6 +27,9 @@ type CF struct {
 	Username string `toml:"username"`
 	Password string `toml:"password"`
 	Token    string `toml:"token"`
+
+	// Firehose configuration
+	IdleTimeout int `toml:"idle_timeout"` // seconds
 }
 
 // Kafka holds Kafka related configuration

--- a/config_test.go
+++ b/config_test.go
@@ -25,6 +25,7 @@ func TestLoadConfig(t *testing.T) {
 					UAAAddr:     "https://uaa.cloudfoundry.net",
 					Username:    "tcnksm",
 					Password:    "xyz",
+					IdleTimeout: 10, // seconds
 				},
 				Kafka: Kafka{
 					Brokers: []string{"192.168.1.1:9092", "192.168.1.2:9092", "192.168.1.3:9092"},

--- a/fixtures/basic.toml
+++ b/fixtures/basic.toml
@@ -6,6 +6,7 @@ doppler_address = "wss://doppler.cloudfoundry.net"
 uaa_address = "https://uaa.cloudfoundry.net"
 username = "tcnksm"
 password = "xyz"
+idle_timeout = 10 # seconds
 
 [kafka]
 brokers = ["192.168.1.1:9092","192.168.1.2:9092","192.168.1.3:9092"]

--- a/vendor/github.com/rakutentech/go-nozzle/.travis.yml
+++ b/vendor/github.com/rakutentech/go-nozzle/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - 1.5.4
-  - 1.6.2
+  - 1.6.4
+  - 1.8
   - tip
 
 script:

--- a/vendor/github.com/rakutentech/go-nozzle/README.md
+++ b/vendor/github.com/rakutentech/go-nozzle/README.md
@@ -31,7 +31,10 @@ config := &nozzle.Config{
 }
    
 // Create default consumer
-consumer, _  := nozzle.NewDefaultConsumer(config)
+consumer, _  := nozzle.NewConsumer(config)
+
+// Start consumer
+consumer.Start()
 
 // Consume events
 event := <-consumer.Events()

--- a/vendor/github.com/rakutentech/go-nozzle/detector.go
+++ b/vendor/github.com/rakutentech/go-nozzle/detector.go
@@ -9,18 +9,18 @@ import (
 )
 
 // SlowDetectCh is channel used to send `slowConsumerAlert` event.
-type SlowDetectCh chan error
+type slowDetectCh chan error
 
 // SlowDetector defines the interface for detecting `slowConsumerAlert`
 // event. By default, defaultSlowDetetor is used. It implements same detection
 // logic as https://github.com/cloudfoundry-incubator/datadog-firehose-nozzle.
-type SlowDetector interface {
+type slowDetector interface {
 	// Detect detects `slowConsumerAlert`. It works as pipe.
 	// It receives events from upstream (RawConsumer) and inspects that events
 	// and pass it to to downstream without modification.
 	//
 	// It returns SlowDetectCh and notify `slowConsumerAlert` there.
-	Detect(<-chan *events.Envelope, <-chan error) (<-chan *events.Envelope, <-chan error, SlowDetectCh)
+	Detect(<-chan *events.Envelope, <-chan error) (<-chan *events.Envelope, <-chan error, slowDetectCh)
 
 	// Stop stops slow consumer detection. If any returns error.
 	Stop() error
@@ -33,7 +33,7 @@ type defaultSlowDetector struct {
 }
 
 // Detect start to detect `slowConsumerAlert` event.
-func (sd *defaultSlowDetector) Detect(eventCh <-chan *events.Envelope, errCh <-chan error) (<-chan *events.Envelope, <-chan error, SlowDetectCh) {
+func (sd *defaultSlowDetector) Detect(eventCh <-chan *events.Envelope, errCh <-chan error) (<-chan *events.Envelope, <-chan error, slowDetectCh) {
 	sd.logger.Println("[INFO] Start detecting slowConsumerAlert event")
 
 	// Create new channel to pass producer
@@ -45,7 +45,7 @@ func (sd *defaultSlowDetector) Detect(eventCh <-chan *events.Envelope, errCh <-c
 	sd.doneCh = make(chan struct{})
 
 	// deteCh is used to send `slowConsumerAlert` event
-	detectCh := make(SlowDetectCh)
+	detectCh := make(slowDetectCh)
 
 	// Detect from from trafficcontroller event messages
 	go func() {

--- a/vendor/github.com/rakutentech/go-nozzle/token.go
+++ b/vendor/github.com/rakutentech/go-nozzle/token.go
@@ -12,11 +12,11 @@ const (
 	defaultUAATimeout = 30 * time.Second
 )
 
-// TokenFetcher is the interface for fetching access token
+// tokenFetcher is the interface for fetching access token
 // From UAA server. By default, defaultTokenFetcher
 // (which is implemented with https://github.com/cloudfoundry-incubator/uaago)
 // is used
-type TokenFetcher interface {
+type tokenFetcher interface {
 	// Fetch fetches the token from Uaa and return it. If any, returns error.
 	Fetch() (string, error)
 }


### PR DESCRIPTION
Allow setting the NOAA IdleTimeout to prevent the nozzle from hanging on broken connections

Related to https://github.com/rakutentech/go-nozzle/pull/9