### PR TITLE
make nozzle able to retry certain times, default 5

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -89,7 +89,7 @@
 		},
 		{
 			"ImportPath": "github.com/rakutentech/go-nozzle",
-			"Rev": "5ea7d8dd3be1bceb05513fcff0a5cba6e806d706"
+			"Rev": "3be6d612baa66145653c0366a13bac3e4f8226b7"
 		},
 		{
 			"ImportPath": "golang.org/x/net/context",

--- a/cli.go
+++ b/cli.go
@@ -48,6 +48,9 @@ const (
 	// DefaultIdleTimeout is the default timeout for receiving a single message
 	// from the firehose
 	DefaultIdleTimeout = 60 * time.Second
+
+	// DefaultRetryCount is the default retry times for consumer to connect to doppler
+	DefaultRetryCount = 5
 )
 
 const (
@@ -171,6 +174,10 @@ func (cli *CLI) Run(args []string) int {
 		config.CF.IdleTimeout = int(DefaultIdleTimeout.Seconds())
 	}
 
+	if config.CF.RetryCount == 0 {
+		config.CF.RetryCount = DefaultRetryCount
+	}
+
 	// Initialize stats collector
 	stats := NewStats()
 	go stats.PerSec()
@@ -193,6 +200,7 @@ func (cli *CLI) Run(args []string) int {
 		Username:       config.CF.Username,
 		Password:       config.CF.Password,
 		IdleTimeout:    time.Duration(config.CF.IdleTimeout) * time.Second,
+		RetryCount:     config.CF.RetryCount,
 		SubscriptionID: config.SubscriptionID,
 		Insecure:       config.InsecureSSLSkipVerify,
 		Logger:         logger,
@@ -210,7 +218,7 @@ func (cli *CLI) Run(args []string) int {
 		logger.Printf("[ERROR] Failed to start nozzle consumer: %s", err)
 		return ExitCodeError
 	}
-		
+
 	// Setup nozzle producer
 	var producer NozzleProducer
 	if debug {

--- a/config.go
+++ b/config.go
@@ -30,6 +30,9 @@ type CF struct {
 
 	// Firehose configuration
 	IdleTimeout int `toml:"idle_timeout"` // seconds
+
+	// How many times consumer will retry to connect to doppler
+	RetryCount int `toml:"retry_count"`
 }
 
 // Kafka holds Kafka related configuration

--- a/vendor/github.com/rakutentech/go-nozzle/consumer.go
+++ b/vendor/github.com/rakutentech/go-nozzle/consumer.go
@@ -115,6 +115,7 @@ type rawDefaultConsumer struct {
 	insecure       bool
 	debugPrinter   noaaConsumer.DebugPrinter
 	idleTimeout    time.Duration
+	retryCount     int
 
 	logger *log.Logger
 }
@@ -137,6 +138,8 @@ func (c *rawDefaultConsumer) Consume() (<-chan *events.Envelope, <-chan error) {
 	}
 
 	nc.SetIdleTimeout(c.idleTimeout)
+
+	nc.SetMaxRetryCount(c.retryCount)
 
 	// Start connection
 	eventChan, errChan := nc.Firehose(c.subscriptionID, c.token)
@@ -184,6 +187,7 @@ func newRawDefaultConsumer(config *Config) (*rawDefaultConsumer, error) {
 		debugPrinter:   config.DebugPrinter,
 		logger:         config.Logger,
 		idleTimeout:    config.IdleTimeout,
+		retryCount:     config.RetryCount,
 	}
 
 	if err := c.validate(); err != nil {

--- a/vendor/github.com/rakutentech/go-nozzle/nozzle.go
+++ b/vendor/github.com/rakutentech/go-nozzle/nozzle.go
@@ -83,6 +83,9 @@ type Config struct {
 	// If 0 (default) the timeout is disabled.
 	IdleTimeout time.Duration
 
+	// RetryCount defines how many times consumer will retry to connect to doppler
+	RetryCount int
+
 	// The following fileds are now only for testing.
 	tokenFetcher tokenFetcher
 	rawConsumer  rawConsumer


### PR DESCRIPTION
in cloudfoundry/noaa consumer, the maxRetryCount is set to 1000 as default, which makes our nozzle keeps on retrying to connect. To avoid this,  we made it possible to set the maxRetryCount, and default value 5 will be applied it not set.