### PR TITLE
Add token refresh logic

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -89,7 +89,7 @@
 		},
 		{
 			"ImportPath": "github.com/rakutentech/go-nozzle",
-			"Rev": "5ea7d8dd3be1bceb05513fcff0a5cba6e806d706"
+			"Rev": "3be6d612baa66145653c0366a13bac3e4f8226b7"
 		},
 		{
 			"ImportPath": "golang.org/x/net/context",

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -89,7 +89,7 @@
 		},
 		{
 			"ImportPath": "github.com/rakutentech/go-nozzle",
-			"Rev": "27fd64b14f6d9c8c4b40e47fe3151e6800bb8c31"
+			"Rev": "f4952a44e07754b06bb79bc844fe7a6eb3140080"
 		},
 		{
 			"ImportPath": "golang.org/x/net/context",

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -89,7 +89,7 @@
 		},
 		{
 			"ImportPath": "github.com/rakutentech/go-nozzle",
-			"Rev": "c499f52745129a83cb7887a5ada6f92a17fec8bd"
+			"Rev": "27fd64b14f6d9c8c4b40e47fe3151e6800bb8c31"
 		},
 		{
 			"ImportPath": "golang.org/x/net/context",

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -89,7 +89,7 @@
 		},
 		{
 			"ImportPath": "github.com/rakutentech/go-nozzle",
-			"Rev": "3be6d612baa66145653c0366a13bac3e4f8226b7"
+			"Rev": "c499f52745129a83cb7887a5ada6f92a17fec8bd"
 		},
 		{
 			"ImportPath": "golang.org/x/net/context",

--- a/cli.go
+++ b/cli.go
@@ -48,6 +48,9 @@ const (
 	// DefaultIdleTimeout is the default timeout for receiving a single message
 	// from the firehose
 	DefaultIdleTimeout = 60 * time.Second
+
+	// DefaultRetryCount is the default retry times for consumer to connect to doppler
+	DefaultRetryCount = 5
 )
 
 const (
@@ -171,6 +174,10 @@ func (cli *CLI) Run(args []string) int {
 		config.CF.IdleTimeout = int(DefaultIdleTimeout.Seconds())
 	}
 
+	if config.CF.RetryCount == 0 {
+		config.CF.RetryCount = DefaultRetryCount
+	}
+
 	// Initialize stats collector
 	stats := NewStats()
 	go stats.PerSec()
@@ -193,6 +200,7 @@ func (cli *CLI) Run(args []string) int {
 		Username:       config.CF.Username,
 		Password:       config.CF.Password,
 		IdleTimeout:    time.Duration(config.CF.IdleTimeout) * time.Second,
+		RetryCount:     config.CF.RetryCount,
 		SubscriptionID: config.SubscriptionID,
 		Insecure:       config.InsecureSSLSkipVerify,
 		Logger:         logger,
@@ -210,7 +218,7 @@ func (cli *CLI) Run(args []string) int {
 		logger.Printf("[ERROR] Failed to start nozzle consumer: %s", err)
 		return ExitCodeError
 	}
-		
+
 	// Setup nozzle producer
 	var producer NozzleProducer
 	if debug {

--- a/config.go
+++ b/config.go
@@ -30,6 +30,9 @@ type CF struct {
 
 	// Firehose configuration
 	IdleTimeout int `toml:"idle_timeout"` // seconds
+
+	// How many times consumer will retry to connect to doppler
+	RetryCount int `toml:"retry_count"`
 }
 
 // Kafka holds Kafka related configuration

--- a/vendor/github.com/rakutentech/go-nozzle/consumer.go
+++ b/vendor/github.com/rakutentech/go-nozzle/consumer.go
@@ -116,7 +116,7 @@ type rawDefaultConsumer struct {
 	debugPrinter   noaaConsumer.DebugPrinter
 	idleTimeout    time.Duration
 	retryCount     int
-	tokenRefresher *defaultTokenFetcher
+	tokenRefresher tokenFetcher
 
 	logger *log.Logger
 }
@@ -141,7 +141,9 @@ func (c *rawDefaultConsumer) Consume() (<-chan *events.Envelope, <-chan error) {
 	nc.SetIdleTimeout(c.idleTimeout)
 
 	nc.SetMaxRetryCount(c.retryCount)
-	nc.RefreshTokenFrom(c.tokenRefresher)
+	if c.tokenRefresher != nil {
+	    nc.RefreshTokenFrom(c.tokenRefresher)
+	}
 
 	// Start connection
 	eventChan, errChan := nc.Firehose(c.subscriptionID, c.token)

--- a/vendor/github.com/rakutentech/go-nozzle/consumer.go
+++ b/vendor/github.com/rakutentech/go-nozzle/consumer.go
@@ -116,6 +116,7 @@ type rawDefaultConsumer struct {
 	debugPrinter   noaaConsumer.DebugPrinter
 	idleTimeout    time.Duration
 	retryCount     int
+	tokenRefresher *defaultTokenFetcher
 
 	logger *log.Logger
 }
@@ -140,6 +141,7 @@ func (c *rawDefaultConsumer) Consume() (<-chan *events.Envelope, <-chan error) {
 	nc.SetIdleTimeout(c.idleTimeout)
 
 	nc.SetMaxRetryCount(c.retryCount)
+	nc.RefreshTokenFrom(c.tokenRefresher)
 
 	// Start connection
 	eventChan, errChan := nc.Firehose(c.subscriptionID, c.token)
@@ -188,6 +190,7 @@ func newRawDefaultConsumer(config *Config) (*rawDefaultConsumer, error) {
 		logger:         config.Logger,
 		idleTimeout:    config.IdleTimeout,
 		retryCount:     config.RetryCount,
+		tokenRefresher: config.tokenFetcher,
 	}
 
 	if err := c.validate(); err != nil {

--- a/vendor/github.com/rakutentech/go-nozzle/consumer.go
+++ b/vendor/github.com/rakutentech/go-nozzle/consumer.go
@@ -115,6 +115,7 @@ type rawDefaultConsumer struct {
 	insecure       bool
 	debugPrinter   noaaConsumer.DebugPrinter
 	idleTimeout    time.Duration
+	retryCount     int
 
 	logger *log.Logger
 }
@@ -137,6 +138,8 @@ func (c *rawDefaultConsumer) Consume() (<-chan *events.Envelope, <-chan error) {
 	}
 
 	nc.SetIdleTimeout(c.idleTimeout)
+
+	nc.SetMaxRetryCount(c.retryCount)
 
 	// Start connection
 	eventChan, errChan := nc.Firehose(c.subscriptionID, c.token)
@@ -184,6 +187,7 @@ func newRawDefaultConsumer(config *Config) (*rawDefaultConsumer, error) {
 		debugPrinter:   config.DebugPrinter,
 		logger:         config.Logger,
 		idleTimeout:    config.IdleTimeout,
+		retryCount:     config.RetryCount,
 	}
 
 	if err := c.validate(); err != nil {

--- a/vendor/github.com/rakutentech/go-nozzle/nozzle.go
+++ b/vendor/github.com/rakutentech/go-nozzle/nozzle.go
@@ -88,7 +88,7 @@ type Config struct {
 
 	// tokenFetcher provides function to get a token, and will be used by noaa consumer
 	// to refresh a token when it is expired
-	tokenFetcher *defaultTokenFetcher
+	tokenFetcher tokenFetcher
 
 	// The following fileds are now only for testing.
 	rawConsumer rawConsumer
@@ -109,23 +109,22 @@ func NewConsumer(config *Config) (Consumer, error) {
 		config.Logger = defaultLogger
 	}
 
-	if config.tokenFetcher == nil {
-		fetcher, err := newDefaultTokenFetcher(config)
-		if err != nil {
-			return nil, fmt.Errorf("failed to construct default token fetcher: %s", err)
-		}
-		config.tokenFetcher = fetcher
-	}
-
 	// If Token is not provided, fetch it by tokenFetcher.
 	if config.Token != "" {
 		config.Logger.Printf("[DEBUG] Using auth token (%s)",
 			maskString(config.Token))
 	} else {
-
 		if config.UaaAddr == "" {
 			return nil, fmt.Errorf("both Token and UaaAddr can not be empty")
 		}
+
+	    if config.tokenFetcher == nil {
+		    fetcher, err := newDefaultTokenFetcher(config)
+		    if err != nil {
+			    return nil, fmt.Errorf("failed to construct default token fetcher: %s", err)
+		    }
+		    config.tokenFetcher = fetcher
+	    }
 
 		// Execute tokenFetcher and get token
 		token, err := config.tokenFetcher.Fetch()

--- a/vendor/github.com/rakutentech/go-nozzle/nozzle.go
+++ b/vendor/github.com/rakutentech/go-nozzle/nozzle.go
@@ -83,6 +83,9 @@ type Config struct {
 	// If 0 (default) the timeout is disabled.
 	IdleTimeout time.Duration
 
+	// RetryCount defines how many times consumer will retry to connect to doppler
+	RetryCount int
+
 	// The following fileds are now only for testing.
 	tokenFetcher tokenFetcher
 	rawConsumer  rawConsumer

--- a/vendor/github.com/rakutentech/go-nozzle/token.go
+++ b/vendor/github.com/rakutentech/go-nozzle/token.go
@@ -80,6 +80,12 @@ func (tf *defaultTokenFetcher) validate() error {
 	return nil
 }
 
+// implement the interface of new noaa token_refresher
+// to get a new token when the existing one is expired
+func (tf *defaultTokenFetcher) RefreshAuthToken() (string, error) {
+	return tf.Fetch()
+}
+
 func newDefaultTokenFetcher(config *Config) (*defaultTokenFetcher, error) {
 	fetcher := &defaultTokenFetcher{
 		uaaAddr:  config.UaaAddr,

--- a/vendor/github.com/rakutentech/go-nozzle/token.go
+++ b/vendor/github.com/rakutentech/go-nozzle/token.go
@@ -19,6 +19,8 @@ const (
 type tokenFetcher interface {
 	// Fetch fetches the token from Uaa and return it. If any, returns error.
 	Fetch() (string, error)
+	RefreshAuthToken() (string, error)
+
 }
 
 type defaultTokenFetcher struct {


### PR DESCRIPTION
we have updated noaa lib, in which token refresher logic is newly involved to fresh token when it is expired and got authorization error trying to connect to doppler.
In this PR, we implement the interface of token_refresh, so that token will be automatically refreshed, and the app itself will not be crashed (and restarted)

