### PR TITLE
Allow to configure compression for the kafka producer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: go
 
 go:
   - 1.6.4
+  - 1.9.2
+  - tip
 
 script:
   - make test

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,6 @@ test-race:
 test-all: vet lint test cover
 
 vet:
-	@go get golang.org/x/tools/cmd/vet
 	go tool vet *.go
 
 lint:

--- a/config.go
+++ b/config.go
@@ -43,6 +43,8 @@ type Kafka struct {
 	RetryMax       int `toml:"retry_max"`
 	RetryBackoff   int `toml:"retry_backoff_ms"`
 	RepartitionMax int `toml:"repartition_max"`
+
+	Compression string `toml:"compression"` // ("gzip", "snappy" or "none", default: "none")
 }
 
 type Topic struct {

--- a/example/kafka-firehose-nozzle.toml
+++ b/example/kafka-firehose-nozzle.toml
@@ -35,6 +35,8 @@ brokers = ["192.168.1.1:9092","192.168.1.2:9092","192.168.1.3:9092"]
 retry_max = 10
 retry_backoff_ms = 500
 
+# Message compression
+compression = "none" # or "snappy", "gzip"
 
   # Topic kafka topic rule
   # Each events are sent to the each topic on kafka


### PR DESCRIPTION
Also, since we're on Go 1.9+ now, there's no need to manually get go vet anymore